### PR TITLE
getPkgs: Fix return empty return value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GRANBase
 Type: Package
 Title: GRAN
-Version: 0.9.40
+Version: 0.9.41
 Author: Gabriel Becker, Cory Barr
 Maintainer: Gabriel Becker <becker.gabriel@gene.com>
 Description: Repository based tools for department and analysis level

--- a/R/sessionInfo.R
+++ b/R/sessionInfo.R
@@ -25,7 +25,7 @@ getPkgs = function(string, pattern = "other attached packages:")
 {
     start = grep(pattern, string)
     if(!length(start))
-        return(list())
+        return(data.frame())
     ##what we care about starts AFTER the other attacehd pkgs line
     start = start + 1
     end = grep("^$", string[start:length(string)])


### PR DESCRIPTION
GRANBase:::getPkgs returns an empty list for 'attached' and 'loaded' packages if none is present in the session info.  This should be the case for a vanilla R.

The 'parsedSessionInfo' class expects a 'data.frame' for the 'attached' and 'loaded' slots, which results in an error.

The patch changes the return value from a list to a data.frame.
