### PR TITLE
R/virtualRepo.R: Fix formatting for man page

### DIFF
--- a/R/virtualRepo.R
+++ b/R/virtualRepo.R
@@ -98,12 +98,10 @@ getPkgVersions = function(pkgs, dir, GRepo = NULL, stoponfail = FALSE,pkgcol = "
     fils
 }
 
-##'makeVirtualRepo
+
+##' Create a virtual repository containing only the specified package versions versions 
 ##'
 ##' Create a virtual repository which contains only the exact packages specified
-##' 
-##' @title Create a virtual repository containing only the specified package versions versions 
-##'
 ##'
 ##' Packages are located via the \code{getPkgVersions} function, which will look in the following places:
 ##' \enumerate{


### PR DESCRIPTION
Title, description and details were displayed as the title before.  This
was because Roxygen got confused by the "##'makeVirtualRepo" statement
at the beginning of the documentation block.