### PR TITLE
Do not email maintainers whose packages are suspended

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GRANBase
 Type: Package
 Title: Creating Continuously Integrated Package Repositories from Manifests
-Version: 1.3.2
+Version: 1.3.3
 Author: Gabriel Becker[aut,cre], Cory Barr [cre,ctb]
 Maintainer: Gabriel Becker <becker.gabriel@gene.com>
 Copyright: Genentech Inc

--- a/NEWS
+++ b/NEWS
@@ -1,11 +1,13 @@
-Changes in version 1.3.0 (2017-05-24)
-API Changes
-    * Email notifications are sent to package authors whose builds failed
-    * Shallow clone while building new packages to improve efficiency
+Changes in version 1.3.3 (2017-06-12)
+Bugfixes
+  * Locate DESCRIPTION file inside the subdirectory of the package downloaded from any Git source
+
+New Features
+  * Email notifications are sent to package authors whose builds failed
 
 Changes in version 1.2.1 (2017-02-09)
 API Changes
-    * Add escape valve which immediately returns NULL from makeRepo if
+  * Add escape valve which immediately returns NULL from makeRepo if
 	  git is not available.
 
 Changes in version 1.1.12 (2016-05-17)
@@ -76,7 +78,7 @@ Changes in version 1.0.11 (2015-06-30)
 Bugfixes
 	* Fix code in repo-specific GRAN package generated during build process.
 New Features
-    * added clear_repo and clear_temp_fils convenience function for clearing out files in order to build a fresh repo.
+  * added clear_repo and clear_temp_fils convenience function for clearing out files in order to build a fresh repo.
 
 
 Changes in version 1.0.10 (2015-06-29)

--- a/R/emailNotifier.R
+++ b/R/emailNotifier.R
@@ -89,6 +89,7 @@ getFailureInfo <- function(repo) {
               "lastbuiltstatus", "maintainer")
 
   RepoResultsDF <- repo_results(repo)[, cnames]
+  RepoResultsDF <- RepoResultsDF[! RepoResultsDF$name %in% suspended_pkgs(repo), ]
   failedPackages <- RepoResultsDF[grep("fail", RepoResultsDF$lastAttemptStatus),]
   failedPackages <- failedPackages[complete.cases(failedPackages[, "maintainer"]),]
   failedPackages$email <- regmatches(failedPackages$maintainer,


### PR DESCRIPTION
Added logic to prevent sending emails to maintainers who have suspended their package(s) in GRAN