### PR TITLE
Bugfixes for check fail criteria and 'suspended' column in repo results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: GRANBase
 Type: Package
 Title: Creating Continuously Integrated Package Repositories from Manifests
-Version: 1.3.3
+Version: 1.3.4
 Author: Gabriel Becker[aut,cre], Cory Barr [cre,ctb]
 Maintainer: Gabriel Becker <becker.gabriel@gene.com>
 Copyright: Genentech Inc

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in version 1.3.4 (2017-06-27)
+Bugfixes
+  * The "suspended" field in the repo results now shows the correct value
+  * Updated criteria to identify check fails
+
 Changes in version 1.3.3 (2017-06-12)
 Bugfixes
   * Locate DESCRIPTION file inside the subdirectory of the package downloaded from any Git source

--- a/R/makeGRANRepos.R
+++ b/R/makeGRANRepos.R
@@ -11,7 +11,7 @@ setMethod("makeRepo", "PkgManifest",
                   version = NA, stringsAsFactors = FALSE)
               sessMan = SessionManifest(manifest = x,
                   versions = vers)
-             
+
               makeRepo(sessMan, cores = cores, scm_auth = scm_auth,
                        build_pkgs = build_pkgs,
                        ...)
@@ -22,7 +22,7 @@ setMethod("makeRepo", "PkgManifest",
 ##' @aliases makeRepo,SessionManifest
 
 setMethod("makeRepo", "SessionManifest",
-          function(x, cores = 3L, build_pkgs = NULL, 
+          function(x, cores = 3L, build_pkgs = NULL,
                    scm_auth = list("bioconductor.org" =
                        c("readonly", "readonly")),
                    ...
@@ -39,7 +39,7 @@ setMethod("makeRepo", "SessionManifest",
 ##' @rdname makerepo
 ##' @aliases makeRepo,GRANRepository
 setMethod("makeRepo", "GRANRepository",
-          function(x, cores = 3L, build_pkgs = NULL,  
+          function(x, cores = 3L, build_pkgs = NULL,
                    scm_auth = list("bioconductor.org" =
                                        c("readonly", "readonly")),
                    ...) {
@@ -51,7 +51,7 @@ setMethod("makeRepo", "GRANRepository",
     if(file.exists(destination(repo)))
         repo2 = tryCatch(loadRepo(paste(destination(repo), "repo.R",
                                         sep="/")), error = function(x) NULL)
-    else 
+    else
         repo2 = suppressWarnings(tryCatch(loadRepo(paste(repo_url(repo), "repo.R", sep="/")),
                                           error = function(x) NULL))
     if(!is.null(repo2) ) {
@@ -71,8 +71,9 @@ setMethod("makeRepo", "GRANRepository",
                                        build_pkgs)
     } else {
         repo_results(repo)$building = !manifest_df(repo)$name %in% suspended_pkgs(repo)
+        repo_results(repo)$suspended <- manifest_df(repo)$name %in% suspended_pkgs(repo)
     }
-    
+
 
     message(paste("Building", sum(getBuilding(repo)), "packages"))
     ##package, build thine self!
@@ -98,7 +99,7 @@ setMethod("makeRepo", "GRANRepository",
     message(paste("starting migrateToFinalRepo", Sys.time()))
     message(paste("Built", sum(getBuilding(repo)), "packages"))
     repo = migrateToFinalRepo(repo)
-    
+
     finalizeRepo(repo)
     repo
 })
@@ -107,7 +108,7 @@ setMethod("makeRepo", "GRANRepository",
 ##' @aliases makeRepo,character
 
 setMethod("makeRepo", "character",
-          function(x, cores = 3L, build_pkgs = NULL,  
+          function(x, cores = 3L, build_pkgs = NULL,
                    scm_auth = list("bioconductor.org" =
                        c("readonly", "readonly")),
                    ...) {
@@ -125,4 +126,3 @@ setMethod("makeRepo", "character",
               makeRepo(repo, cores = cores, build_pkgs = build_pkgs,
                        scm_auth = scm_auth, ...)
           })
-

--- a/R/testPackages.R
+++ b/R/testPackages.R
@@ -80,7 +80,7 @@ installTest = function(repo, cores = 3L)
     ## protect ourselves here by asserting dimension conformity was preserved:
     ## bres should contain 1 row for each TRUE in binds
     stopifnot(nrow(bres) == sum(binds))
-    
+
 
     res = install.packages2(bres$name, lib = loc,
         repos = reps,
@@ -91,7 +91,7 @@ installTest = function(repo, cores = 3L)
     if(length(success) != nrow(bres) || length(success) != sum(binds))
         stop("length mismatch between Install test output and packages tested")
     ## default is the staging_logs dir when repo specified, which is correct here
-    cleanupInstOut(repo= repo) 
+    cleanupInstOut(repo= repo)
 
 
 
@@ -217,7 +217,7 @@ checkTest = function(repo, cores = 3L)
         stop("Fatal error. I didn't get check output for all checked packages.")
 
     success = mapply(function(nm, out, repo) {
-        if(errorOrNonZero(out) || any(grepl("ERROR", out, fixed=TRUE))) {
+        if(errorOrNonZero(out) || any(grepl("Status: [[:digit:]]+ ERROR", out, fixed=FALSE))) {
             logfun(repo)(nm, "R CMD check failed.", type = "both")
             outToErrLog = TRUE
 


### PR DESCRIPTION
* The "suspended" field in the repo results now shows the correct value
* Updated criteria to identify check fails